### PR TITLE
Track release versions of eleventy-lazy-images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1997,8 +1997,8 @@
       "dev": true
     },
     "eleventy-plugin-lazyimages": {
-      "version": "github:liamfiddler/eleventy-plugin-lazyimages#9882b9ca93715bae50518c5253d6fcc78d006cc4",
-      "from": "github:liamfiddler/eleventy-plugin-lazyimages#9882b9ca93715bae50518c5253d6fcc78d006cc4",
+      "version": "1.1.1",
+      "resolved": "github:liamfiddler/eleventy-plugin-lazyimages#3090014a1c3a7ce52210363da11356fa5ba2e117",
       "dev": true,
       "requires": {
         "jimp": "^0.9.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "@11ty/eleventy": "^0.10.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1",
     "clean-css": "^4.2.3",
-    "eleventy-plugin-lazyimages": "github:liamfiddler/eleventy-plugin-lazyimages"
+    "eleventy-plugin-lazyimages": "^1.1.1"
   }
 }


### PR DESCRIPTION
When I first added eleventy-lazy-images the README had the instruction
to install the "git" version:

    npm install liamfiddler/eleventy-plugin-lazyimages --save-dev

Nowadays the project has passed version 1.0 and we can use the
officially released versions instead.