### PR TITLE
Always show the date and author below the post title

### DIFF
--- a/content/_includes/css/style.css
+++ b/content/_includes/css/style.css
@@ -61,8 +61,12 @@ pre {
   margin-bottom: 1.5rem;
 }
 
-footer {
-  margin-top: 1.5rem;
+header h1,
+header h2 {
+  margin-bottom: 0.5rem;
+}
+
+.meta {
   margin-bottom: 1.5rem;
   font-size: 0.75rem;
   letter-spacing: 1.5px;

--- a/content/_includes/layouts/post.html
+++ b/content/_includes/layouts/post.html
@@ -4,15 +4,15 @@ layout: layouts/default
 <article>
   <header>
     <h1>{{ title }}</h1>
+    <div class="meta">
+      <time datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date: "%e %B %Y" }}</time>
+      &middot;
+      {{ author }}
+    </div>
   </header>
   <div>
     {{ content }}
   </div>
-  <footer>
-    <time datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date: "%e %B %Y" }}</time>
-    &middot;
-    {{ author }}
-  </footer>
 </article>
 
 <aside class="about">

--- a/content/index.html
+++ b/content/index.html
@@ -17,7 +17,14 @@ pagination:
 
 {% for post in posts %}
 <article class="post" lang="{{ post.data.language }}">
-  <h2><a href="{{ post.url }}">{{ post.data.title }}</a></h2>
+  <header>
+    <h2><a href="{{ post.url }}">{{ post.data.title }}</a></h2>
+    <div class="meta">
+      <time datetime="{{ post.date | date: "%Y-%m-%d" }}">{{ post.date | date: "%e %B %Y" }}</time>
+      &middot;
+      {{ post.data.author }}
+    </div>
+  </header>
   {{ post.templateContent }}
 </article>
 {% endfor %}


### PR DESCRIPTION
The previous iteration was closer to how the metadata was displayed on
the old Wordpress blog.

I'd argue that grouping the author and date with the title makes it
easier to find these details. Seeing the date right away will probably
inform the decision whether you want to read a post.

Before
<img width="937" alt="The title  of a blog post, followed by part of the post" src="https://user-images.githubusercontent.com/677998/102750775-b528b080-4366-11eb-8f67-e7864bf33094.png">


After

<img width="937" alt="The title  of a blog post, followed by the publishing date and author and then the post itself" src="https://user-images.githubusercontent.com/677998/102750784-ba85fb00-4366-11eb-8578-35f8c768418c.png">
