### PR TITLE
Remove summary field

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ title: "User story mapping: a retrospective"
 date: 2017-03-30
 language: en
 author: Jane Appleseed
-summary: We have been consistently making user story maps for the last 6 months. This is what we've learned.
 ---
 ```
 
@@ -56,7 +55,6 @@ The front matter should have these fields:
 - `date`: the publication date in `YYYY-MM-DD` format. This is used in the permalink.
 - `language`: `en` or `de`. This is used to tell the browser and search engines which language is used, so that they don't need to guess.
 - `author`: your name :)
-- `summary`: a summary/abstract/teaser of the article. This can be displayed in search results or previews on social media.
 
 ### Images
 

--- a/content/posts/a-subtle-change-in-pdf-output.md
+++ b/content/posts/a-subtle-change-in-pdf-output.md
@@ -3,7 +3,6 @@ title: A subtle change in PDF output
 date: 2021-07-05
 language: en
 author: Dimiter Petrov
-summary: How a fallback font was breaking an integration test
 ---
 
 ## The problem


### PR DESCRIPTION
The `summary` field in the markdown header has been renamed to `postSummary`. This is a possible solution for the conflicting `summary` field used in the website code.

See https://trello.com/c/jzuw2cbe/185-gatsby-build-issue-conflicting-types for a more detailed explanation