### PR TITLE
Include meta tags for social media

### DIFF
--- a/content/_includes/layouts/default.html
+++ b/content/_includes/layouts/default.html
@@ -7,6 +7,12 @@
     <style>{%- embeddedStyle "css/style.css" -%}</style>
     <link rel="icon" href="/images/icons/icon-48x48.png">
     <link rel="apple-touch-icon" sizes="192x192" href="/images/icons/icon-192x192.png"/>
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@simplificator" />
+    <meta property="og:url" content="https://blog.simplificator.com{{ page.url }}" />
+    <meta property="og:title" content="{{ title }}" />
+    <meta property="og:description" content="" />
   </head>
   <body>
     <nav>


### PR DESCRIPTION
Social networks like Twitter and LinkedIn use these tags to show rich
previews of the link.

While the most popular standard for this is Open Graph, Twitter defines
its own tags. However, according to the Twitter developer documentation,
Twitter uses Open Graph as a fallback, so we don't need to duplicate
information:

https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started

The description is set to an empty string as none of the posts have a
summary.

We don't have any preview images yet either. We could generate them with
techniques such as the following:

- https://www.zachleat.com/web/automatic-opengraph/
- https://github.blog/2021-06-22-framework-building-open-graph-images/