### PR TITLE
Identify posts collection by path

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -15,6 +15,10 @@ function normalizedExtension(extension) {
 module.exports = (config) => {
   config.addPassthroughCopy("content/images")
 
+  config.addCollection("posts", (collectionApi) => {
+    return collectionApi.getFilteredByGlob(["content/posts/*.md"])
+  })
+
   config.addShortcode('embeddedStyle', (path) => {
     let completePath = `content/_includes/${path}`
     return new CleanCSS({}).minify([completePath]).styles

--- a/content/index.html
+++ b/content/index.html
@@ -4,7 +4,7 @@ title: Simplificator blog
 language: en
 permalink: '/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber}}/{% endif %}'
 pagination:
-  data: collections.post
+  data: collections.posts
   reverse: true
   size: 10
   alias: posts

--- a/content/posts/posts.json
+++ b/content/posts/posts.json
@@ -1,5 +1,4 @@
 {
   "permalink": "/{{ page.date | date: '%Y/%m/%d' }}/{{ page.fileSlug }}/index.html",
-  "tags": "post",
   "layout": "layouts/post"
 }


### PR DESCRIPTION
We intend to add tags to each post. That will be achieved with the
`tags` key in each post's frontmatter.

The `tags` key is already used in the posts directory frontmatter
(posts.json) to mark the collection of all posts. In 11ty, the data from
the frontmatter in individual posts takes precendence over the
directory-level data. Because of this the `post` tag will be overwritten
for posts that define tags in their frontmatter and these posts will no
longer be in the `post` collection. (We use this collection to list
posts on the index page)

Luckily there are other ways to define collections, like the Eleventy
collection API used in this commit.

Documentation:

- Data cascade: https://www.11ty.dev/docs/data-cascade/
- Collections: https://www.11ty.dev/docs/collections/