### PR TITLE
Tag blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ title: "User story mapping: a retrospective"
 date: 2017-03-30
 language: en
 author: Jane Appleseed
+tags:
+  - user-story-mapping
+  - projects
 ---
 ```
 
@@ -55,6 +58,10 @@ The front matter should have these fields:
 - `date`: the publication date in `YYYY-MM-DD` format. This is used in the permalink.
 - `language`: `en` or `de`. This is used to tell the browser and search engines which language is used, so that they don't need to guess.
 - `author`: your name :)
+
+Optional fields:
+
+- `tags`: a list of tags for the blog post
 
 ### Images
 

--- a/content/posts/a-subtle-change-in-pdf-output.md
+++ b/content/posts/a-subtle-change-in-pdf-output.md
@@ -3,6 +3,9 @@ title: A subtle change in PDF output
 date: 2021-07-05
 language: en
 author: Dimiter Petrov
+tags:
+  - testing
+  - docker
 ---
 
 ## The problem

--- a/content/posts/alte-urls-neue-urls.md
+++ b/content/posts/alte-urls-neue-urls.md
@@ -3,6 +3,8 @@ title: "Alte URLs, neue URLs"
 date: 2013-11-27
 language: de
 author: Simplificator
+tags:
+  - ruby
 ---
 
 Neues CMS neue URLs und nichts mehr auffindbar?

--- a/content/posts/an-informal-intro-to-agile.md
+++ b/content/posts/an-informal-intro-to-agile.md
@@ -3,6 +3,8 @@ title: "An informal intro to agile"
 date: 2012-10-18
 language: en
 author: Simplificator
+tags:
+  - agile
 ---
 
 This is based on an email to an interested friend, and I thought it might have some value to others.

--- a/content/posts/apero.md
+++ b/content/posts/apero.md
@@ -3,6 +3,8 @@ title: "Apéro"
 date: 2013-03-08
 language: de
 author: Simplificator
+tags:
+  - events
 ---
 
 Am 15. März um 17:00 gibt es an der Pfingstweidstrasse 6, im 2. Stock einen Apéro. Wir laden alle Kunden und Freunde ein, also auch dich!

--- a/content/posts/baruco-2014.md
+++ b/content/posts/baruco-2014.md
@@ -3,6 +3,9 @@ title: "Baruco 2014"
 date: 2014-09-13
 language: en
 author: Simplificator
+tags:
+  - events
+  - ruby
 ---
 
 {% image "./content/images/tumblr_nbtwbnna7x1s5gaabo1_1280.jpg", "" %}

--- a/content/posts/being-a-software-developer-intern-simplificator.md
+++ b/content/posts/being-a-software-developer-intern-simplificator.md
@@ -3,6 +3,8 @@ title: "Being a Software Developer Intern @Simplificator"
 date: 2018-01-15
 language: en
 author: Chanel Greco
+tags:
+  - internship
 ---
 
 As I’m writing this blog post, I’m ending my 6-month internship at Simplificator as a software developer. A month ago I turned 34. Yes, you read correctly, at an age where most employees are looking to boost their careers, I decided to go back to square one and learn how to code. But why did I choose to do so?

--- a/content/posts/ci-servers-evaluation.md
+++ b/content/posts/ci-servers-evaluation.md
@@ -3,6 +3,8 @@ title: "CI servers evaluation"
 date: 2012-09-19
 language: en
 author: Simplificator
+tags:
+  - testing
 ---
 
 Currently we are using [Jenkins](http://www.jenkins-ci.org/) as our CI server. But we are not completely satisfied with it. The main problem with [Jenkins](http://www.jenkins-ci.org/) is that it is overloaded with features which makes the UI quite messy. We also hit a problem with upgrading it to a never version, which was probably a conflict between war installer and a debian package. After the upgrade it stopped working and we spent the afternoon bringing it back to life. We are also missing support for projects grouping. And last but not least to make it work you need to install bunch of plugins, which then you need to keep up to date and maintain.

--- a/content/posts/computers-are-used-to-share-pictures-words-and.md
+++ b/content/posts/computers-are-used-to-share-pictures-words-and.md
@@ -3,6 +3,8 @@ title: "Web development explained simply"
 date: 2013-02-27
 language: en
 author: Simplificator
+tags:
+  - software-development
 ---
 
 {% image "./content/images/tumblr_mbv2y4gjow1r0nwmko1_500.png", "" %}

--- a/content/posts/configuration-load-order-in-rails.md
+++ b/content/posts/configuration-load-order-in-rails.md
@@ -3,6 +3,10 @@ title: "Configuration load order in Rails"
 date: 2015-01-19
 language: en
 author: Pascal Betz
+tags:
+  - configuration
+  - rails
+  - ruby
 ---
 
 Ever wondered what the load order of the various configuration files of Rails is?

--- a/content/posts/dare-to-question.md
+++ b/content/posts/dare-to-question.md
@@ -3,6 +3,9 @@ title: "Dare to question"
 date: 2015-02-12
 language: en
 author: Lukas Eppler
+tags:
+  - values
+  - philosophy
 ---
 
 #### We had a problem.

--- a/content/posts/diff-einer-datei-via-git.md
+++ b/content/posts/diff-einer-datei-via-git.md
@@ -3,6 +3,8 @@ title: "Diff einer Datei via git"
 date: 2013-12-18
 language: de
 author: Simplificator
+tags:
+  - git
 ---
 
 Mit git kann man auf einfache Weise einen Diff eines Files über verschiedene Branches machen:

--- a/content/posts/encoding-hell-part-2.md
+++ b/content/posts/encoding-hell-part-2.md
@@ -3,6 +3,9 @@ title: "éncoding hèll (part 2)"
 date: 2015-01-10
 language: en
 author: Pascal Betz
+tags:
+  - encoding
+  - ruby
 ---
 
 How does Ruby deal with encoding? Here are some important parts.

--- a/content/posts/encoding-hell-part-3.md
+++ b/content/posts/encoding-hell-part-3.md
@@ -3,6 +3,9 @@ title: "éncöding hèll (part 3)"
 date: 2015-01-12
 language: en
 author: Pascal Betz
+tags:
+  - encoding
+  - ruby
 ---
 
 The (currently) last part of my encoding hell series. To finish up I'll show some samples.

--- a/content/posts/encoding-hell.md
+++ b/content/posts/encoding-hell.md
@@ -3,6 +3,9 @@ title: "éncöding hèll (part 1)"
 date: 2015-01-07
 language: en
 author: Pascal Betz
+tags:
+  - encoding
+  - ruby
 ---
 
 If you ended up reading this, then you know what i am talking about. It's this garbled up text. That umlaut which got lost. Those diacritical marks that don't show up. And then first you blame the accent-grave-french, the umlaut-germans, the diacritic-czechs and so on (not even mentioning chinese/japanese/...languages) .

--- a/content/posts/euruko-sofia-2016-my-first-ruby-conference.md
+++ b/content/posts/euruko-sofia-2016-my-first-ruby-conference.md
@@ -3,6 +3,9 @@ title: "EuRuKo Sofia 2016: My first Ruby Conference"
 date: 2016-10-24
 language: en
 author: Marion Schleifer
+tags:
+  - ruby
+  - events
 ---
 
 I was really excited to go to EuRuKo 2016, because it was the first time for me to attend an event such as this. The conference was on Friday and on Saturday, and we arrived on Thursday morning to discover Sofia. As it turned out, the city is quite small, so a few hours were enough to do so. We then ran into some other Swiss guys who attended the conference (Pascal among them) and when they were talking about past conferences, I really couldn't wait anymore for the next day.

--- a/content/posts/feature-testing-mobile-variants.md
+++ b/content/posts/feature-testing-mobile-variants.md
@@ -3,6 +3,11 @@ title: Feature testing mobile variants
 date: 2015-12-18
 language: en
 author: Thomas Ritter
+tags:
+  - rails
+  - rspec
+  - ruby
+  - testing
 ---
 
 For a project, we wanted to write a feature spec for the [mobile variant](http://guides.rubyonrails.org/4_1_release_notes.html#action-pack-variants) of the site. Instinctively, the first thing I did was google. I found nothing. The next thing I did was think. I came up with this, which worked:

--- a/content/posts/filter-rails-sql-log-in-production.md
+++ b/content/posts/filter-rails-sql-log-in-production.md
@@ -3,6 +3,10 @@ title: Filter Rails SQL log in production
 date: 2015-02-02
 language: en
 author: Thomas Ritter
+tags:
+  - logging
+  - rails
+  - ruby
 ---
 
 In order to debug a problem, which only occurred in production, we recently wanted to tweak our Rails SQL logs to only show the access to a specific table.

--- a/content/posts/finding-column-names-using-dbi.md
+++ b/content/posts/finding-column-names-using-dbi.md
@@ -3,6 +3,9 @@ title: "Finding column names using DBI"
 date: 2014-03-31
 language: en
 author: Simplificator
+tags:
+  - database
+  - ruby
 ---
 
 A useful snippet, should you ever require to get the column names of a table that you are connecting through DBI:

--- a/content/posts/gastbeitrag-personalvermittler.md
+++ b/content/posts/gastbeitrag-personalvermittler.md
@@ -3,6 +3,8 @@ title: "Gastbeitrag Personalvermittler"
 date: 2015-06-19
 language: de
 author: Christoph Dopp
+tags:
+  - recruiters
 ---
 
 Im Blogeintrag [„Personalvermittler“](http://blog.simplificator.com/2015/04/30/personalvermittler/) teilt Pascal Betz seine Erfahrungen betreffend Personalvermittler.

--- a/content/posts/getting-started-with-hanami-and-graphql.md
+++ b/content/posts/getting-started-with-hanami-and-graphql.md
@@ -3,6 +3,9 @@ title: "Getting Started with Hanami and GraphQL"
 date: 2016-12-07
 language: en
 author: Cédric Wider
+tags:
+  - ruby
+  - graphql
 ---
 
 ## What is GraphQL?

--- a/content/posts/girls-on-rails.md
+++ b/content/posts/girls-on-rails.md
@@ -3,6 +3,9 @@ title: "Girls on Rails"
 date: 2012-11-18
 language: de
 author: Simplificator
+tags:
+  - events
+  - rails
 ---
 
 Simplificator sponsert den [Rails Girls Zürich](http://railsgirls.ch)\-Event am 3. und 4. November 2012, und der Anmeldeschluss ist heute Freitag!

--- a/content/posts/handling-errors-in-ruby-on-rails.md
+++ b/content/posts/handling-errors-in-ruby-on-rails.md
@@ -3,6 +3,9 @@ title: "Handling errors in Ruby on Rails"
 date: 2015-03-13
 language: en
 author: Pascal Betz
+tags:
+  - rails
+  - ruby
 ---
 
 Rails offers multiple ways to deal with exceptions and depending on what you want to achieve you can pick either of those solutions. Let me walk you through the possibilities.

--- a/content/posts/how-to-kill-processes-on-windows-using-ruby.md
+++ b/content/posts/how-to-kill-processes-on-windows-using-ruby.md
@@ -3,6 +3,9 @@ title: How to kill processes on Windows using Ruby
 date: 2016-01-18
 language: en
 author: Lucian Cancescu
+tags:
+  - ruby
+  - windows
 ---
 
 In order to terminate a process in Ruby you can use the kill method in the of the Process class in the following way:

--- a/content/posts/how-we-sped-up-our-model-spec-to-run-12-times-faster.md
+++ b/content/posts/how-we-sped-up-our-model-spec-to-run-12-times-faster.md
@@ -3,6 +3,10 @@ title: How we sped up our model spec to run 12 times faster
 date: 2015-02-19
 language: en
 author: Thomas Ritter
+tags:
+  - cancan
+  - rspec
+  - ruby
 ---
 
 We are using [cancancan](https://github.com/CanCanCommunity/cancancan) as an authorization gem for one of our applications. To make sure that our authorization rules are correct, we unit-tested the `Ability` object. In the beginning, the test was quite fast, but the more rules we added, the longer it took to run the whole model test. When we analyzed what was slowing down our test, we saw that quite some time is actually used persisting our models to the database with [factory\_girl](https://github.com/thoughtbot/factory_girl) as part of the test setup. It took a bit more than 60 seconds to run the whole ability spec, which is far too much for a model test.

--- a/content/posts/incrementdecrement-counters-in-activerecord.md
+++ b/content/posts/incrementdecrement-counters-in-activerecord.md
@@ -3,6 +3,10 @@ title: increment/decrement counters in ActiveRecord
 date: 2015-01-23
 language: en
 author: Pascal Betz
+tags:
+  - database
+  - locking
+  - ruby
 ---
 
 In lots of web apps you need to count something. Availability of products, number of login attempts, visitors on a page and so on.

--- a/content/posts/insights-from-finance-2-0.md
+++ b/content/posts/insights-from-finance-2-0.md
@@ -3,6 +3,8 @@ title: "Insights from Finance 2.0"
 date: 2018-03-23
 language: en
 author: Chanel Greco
+tags:
+  - events
 ---
 
 {% image "./content/images/badge_2.jpg", "Conference badge" %}

--- a/content/posts/learning-to-code-at-simplificator.md
+++ b/content/posts/learning-to-code-at-simplificator.md
@@ -3,6 +3,8 @@ title: "Learning to Code at Simplificator"
 date: 2016-10-31
 language: en
 author: Marion Schleifer
+tags:
+  - internship
 ---
 
 When I finished my Master in Economics in September 2014, I didn't want to take on some random office job where I do the same every day. I wanted a job where I have to learn something every day and where I have to keep up to date with what I do. I then decided to take on a 50% accounting job, in order to make a living, and meanwhile, I decided to learn programming. I started with online tutorials and practised on my own. However, I soon realised that, at some point, I didn't get any further. I had a basic knowledge about data structures and control structures, but I had no idea where I would have to use them in a real project.

--- a/content/posts/local-time-gem.md
+++ b/content/posts/local-time-gem.md
@@ -3,6 +3,9 @@ title: "local_time gem"
 date: 2013-12-03
 language: de
 author: Simplificator
+tags:
+  - rails
+  - timezones
 ---
 
 Eine Rails Engine mit helper methoden und Javascript um Timestamps und Dates in lokalen Zeiten darzustellen.

--- a/content/posts/love-what-you-do.md
+++ b/content/posts/love-what-you-do.md
@@ -3,6 +3,8 @@ title: "Love what you do"
 date: 2015-11-18
 language: en
 author: Lukas Eppler
+tags:
+  - values
 ---
 
 You're a professional. Your work is part of who you are. Connect the work with your motivation, and find out what makes you tick. If you can be authentic in your work, do things the right way, you'll get a feeling of achievement, and of being one with your work. This is important because it's the only way to employ the unconscious part of your brain, your intuition. This part helps you be great - if you have to think about every step you do you slow yourself down. If it doesn't feel right, think about it and get the roadblocks away. You know you're doing it right when you truly love what you do.

--- a/content/posts/ms-access-und-ruby.md
+++ b/content/posts/ms-access-und-ruby.md
@@ -3,6 +3,8 @@ title: "MS Access und Ruby?"
 date: 2014-02-24
 language: de
 author: Simplificator
+tags:
+  - ruby
 ---
 
 Auch das geht.

--- a/content/posts/neues-zu-brotseiten.md
+++ b/content/posts/neues-zu-brotseiten.md
@@ -3,6 +3,8 @@ title: "Neues zu Brotseiten"
 date: 2013-12-23
 language: de
 author: Simplificator
+tags:
+  - ios
 ---
 
 Die Brotseiten iOS App ist im App Store [verfügbar](https://itunes.apple.com/ch/app/id726147749) und natürlich auch auf unserer Seite [dokumentiert](http://www.simplificator.com/de/projects/35-ios-app-fur-kurzgeschichten).

--- a/content/posts/notrufuhr-von-swisscom-und-limmex.md
+++ b/content/posts/notrufuhr-von-swisscom-und-limmex.md
@@ -3,6 +3,9 @@ title: "Notrufuhr von Swisscom und Limmex"
 date: 2012-11-16
 language: de
 author: Simplificator
+tags:
+  - swiss-made
+  - watch
 ---
 
 Zusammen mit Limmex lanciert Swisscom heute eine Swisscom Notrufuhr. Simplificator hat dazu das bereits vorhandene System angepasst und erweitert. Neu ist die Mandantenfähigkeit sowie ein eigenes Design für Swisscom.

--- a/content/posts/our-ci-notification-system-with-an-old-school-led.md
+++ b/content/posts/our-ci-notification-system-with-an-old-school-led.md
@@ -3,6 +3,8 @@ title: "Our CI notification system with an old school LED board"
 date: 2013-03-14
 language: en
 author: Simplificator
+tags:
+  - testing
 ---
 
 {% image "./content/images/tumblr_mjnpjmwy4v1s5gaabo1_1280.jpg", "LED board" %}

--- a/content/posts/our-new-laptop-sleeves-arrived.md
+++ b/content/posts/our-new-laptop-sleeves-arrived.md
@@ -3,6 +3,8 @@ title: "Our new laptop sleeves arrived"
 date: 2015-03-09
 language: en
 author: Pascal Betz
+tags:
+  - values
 ---
 
 {% image "./content/images/b_phppkxaaees3_.jpg", "Simplificator laptop sleeves" %}

--- a/content/posts/personalvermittler.md
+++ b/content/posts/personalvermittler.md
@@ -3,6 +3,9 @@ title: "Personalvermittler"
 date: 2015-04-30
 language: de
 author: Pascal Betz
+tags:
+  - recruiters
+  - values
 ---
 
 {% image "./content/images/iphone_no_caller_id_640.jpg", "iPhone no caller ID" %}

--- a/content/posts/preparing-for-the-apero-this-evening.md
+++ b/content/posts/preparing-for-the-apero-this-evening.md
@@ -3,6 +3,8 @@ title: "Apero preparation"
 date: 2013-03-15
 language: en
 author: Simplificator
+tags:
+  - events
 ---
 
 Preparing for the Apero this evening….

--- a/content/posts/rails-girls-basel.md
+++ b/content/posts/rails-girls-basel.md
@@ -3,6 +3,9 @@ title: "Rails Girls Basel"
 date: 2013-04-05
 language: de
 author: Simplificator
+tags:
+  - events
+  - rails
 ---
 
 Heute und Morgen ist Rails Girls Basel. Simplificator ist sponsor und wünscht allen Teilnehmern viel Spass und Erfolg. Ein grosses Dankeschön auch an die Organisatoren und Coaches!

--- a/content/posts/rails-girls-helsinki.md
+++ b/content/posts/rails-girls-helsinki.md
@@ -3,6 +3,9 @@ title: "Rails Girls Helsinki"
 date: 2015-05-27
 language: en
 author: Marion Schleifer
+tags:
+  - events
+  - rails
 ---
 
 Two Simplificators, Marion and Ferdinand, have been to [Rails Girls in Helsinki](http://railsgirls.com/helsinki) as coaches. Here is a short travel report.

--- a/content/posts/railsgirls-basel-auf-telebasel.md
+++ b/content/posts/railsgirls-basel-auf-telebasel.md
@@ -3,6 +3,8 @@ title: "RailsGirls Basel auf Telebasel"
 date: 2013-04-11
 language: de
 author: Simplificator
+tags:
+  - events
 ---
 
 Das Video ist auf der [Telebasel Webseite](http://www.telebasel.ch/de/tv-archiv/&id=366823941) zu finden. Nach einem Bericht über Poetry Slam folgt RailsGirls Basel (ab 2:31).

--- a/content/posts/railsgirls-basel-geht-los-viel-spass-und-erfolg.md
+++ b/content/posts/railsgirls-basel-geht-los-viel-spass-und-erfolg.md
@@ -3,6 +3,9 @@ title: "Rails Girls Basel 2013"
 date: 2013-04-06
 language: de
 author: Simplificator
+tags:
+  - events
+  - rails
 ---
 
 RailsGirls Basel geht los….viel Spass und Erfolg.

--- a/content/posts/railsgirls-basel.md
+++ b/content/posts/railsgirls-basel.md
@@ -3,6 +3,9 @@ title: "Railsgirls Basel"
 date: 2013-03-12
 language: de
 author: Simplificator
+tags:
+  - events
+  - rails
 ---
 
 Am 5. und 6. April findet eine weitere Ausgabe von Rails Girls statt. Dieses mal in Basel. Simlpificator ist wieder als Sponsor mit dabei.

--- a/content/posts/railsgirls.md
+++ b/content/posts/railsgirls.md
@@ -3,6 +3,9 @@ title: "Railsgirls"
 date: 2012-11-14
 language: de
 author: Simplificator
+tags:
+  - events
+  - rails
 ---
 
 Endlich ein paar Worte über den [Rails Girls Zürich](http://railsgirls.ch)–Event am 3. und 4. November 2012. Wir konnten den Event als Sponsoren unterstützen. 

--- a/content/posts/rake-execute-vs-invoke.md
+++ b/content/posts/rake-execute-vs-invoke.md
@@ -3,6 +3,9 @@ title: "Rake: execute vs. invoke"
 date: 2014-12-30
 language: en
 author: Simplificator
+tags:
+  - rake
+  - ruby
 ---
 
 I recently had to write custom rake tasks for a Rails project which deals with multiple databases (one Rails database and 1+ additional databases). The way we deal with multiple databases should be covered in another post. Now i only want to show the difference between `invoke` and `execute`.

--- a/content/posts/rake-tasks-with-parameters.md
+++ b/content/posts/rake-tasks-with-parameters.md
@@ -3,6 +3,9 @@ title: "Rake Tasks With Parameters"
 date: 2015-04-09
 language: en
 author: Thomas Ritter
+tags:
+  - rake
+  - ruby
 ---
 
 Rake tasks are a convenient method to automate repeating tasks and also make them available via the command line. Oftentimes these tasks can be executed without any user input. Think of a built-in task like "db:migrate" -- it does not take any arguments. There's other tasks that in fact take arguments. Usually, they work like this: `rake the_namespace:the_task[arg1,arg2]`.

--- a/content/posts/recruiters.md
+++ b/content/posts/recruiters.md
@@ -3,6 +3,8 @@ title: "Recruiters"
 date: 2013-02-05
 language: de
 author: Simplificator
+tags:
+  - recruiters
 ---
 
 Und ein weiteres mal darf ich mich über Recruiters aufregen…ein weiteres mal über JPeople aus England.

--- a/content/posts/returning-enumerator-unless-block-given.md
+++ b/content/posts/returning-enumerator-unless-block-given.md
@@ -3,6 +3,8 @@ title: Returning Enumerator unless block_given?
 date: 2015-03-27
 language: en
 author: Pascal Betz
+tags:
+  - ruby
 ---
 
 The [Enumerable](http://ruby-doc.org/core-2.2.1/Enumerable.html) module gives you methods to search, iterate, traverse and sort elements of a collection. All you need to to is to implement `each` and include the mixin.

--- a/content/posts/ruby-and-the-double-splat-operator.md
+++ b/content/posts/ruby-and-the-double-splat-operator.md
@@ -3,6 +3,8 @@ title: "Ruby and the double splat operator"
 date: 2015-03-20
 language: en
 author: Pascal Betz
+tags:
+  - ruby
 ---
 
 If you have been programming ruby for a while then you have seen the splat operator. It can be used to define methods that accept a variable length argument list like so:

--- a/content/posts/ruby-api-doc-and-module.md
+++ b/content/posts/ruby-api-doc-and-module.md
@@ -3,6 +3,8 @@ title: "Ruby API doc and Module"
 date: 2015-04-24
 language: en
 author: Pascal Betz
+tags:
+  - ruby
 ---
 
 The Ruby [API doc](http://ruby-doc.org/core-2.2.2) is a great source for information about my programming language of choice. Even after years of writing Ruby code i learn new tricks and features. Lately I've been looking into the [Module](http://ruby-doc.org/core-2.2.2/Module.html) class in more detail.

--- a/content/posts/setting-up-cypress-with-rails.md
+++ b/content/posts/setting-up-cypress-with-rails.md
@@ -3,6 +3,10 @@ title: "Setting up Cypress with Rails"
 date: 2019-10-11
 language: en
 author: Dimiter Petrov
+tags:
+  - rails
+  - ruby
+  - testing
 ---
 
 [Cypress.io](https://cypress.io) has very nice tooling for testing. We have been experimenting with it in various projects, one of which is a Rails application.

--- a/content/posts/simple-vagrant-setup-for-rails-applications.md
+++ b/content/posts/simple-vagrant-setup-for-rails-applications.md
@@ -3,6 +3,8 @@ title: Simple Vagrant setup for Rails applications
 date: 2015-01-23
 language: en
 author: Lucian Cancescu
+tags:
+  - vagrant
 ---
 
 There are many reasons on why you should use Vagrant for your development, as described [here](https://docs.vagrantup.com/v2/why-vagrant) and [here](http://superuser.com/a/588334).

--- a/content/posts/simplification-conference.md
+++ b/content/posts/simplification-conference.md
@@ -3,6 +3,8 @@ title: "Simplification Conference"
 date: 2015-09-18
 language: de
 author: Pascal Betz
+tags:
+  - events
 ---
 
 {% image "./content/images/simplification-conference-2015.png", "" %}

--- a/content/posts/simplificator-an-der-baruco-konferenz.md
+++ b/content/posts/simplificator-an-der-baruco-konferenz.md
@@ -3,6 +3,9 @@ title: "Simplificator an der Baruco Konferenz"
 date: 2014-09-13
 language: de
 author: Simplificator
+tags:
+  - events
+  - ruby
 ---
 
 Nachdem wir gestern Vorträge über die internas von _ActiveRecord_, _Type Safety_ und _Release Responsible_ gehört haben, geht es heute mit _Optimization_ und _Services_ weiter.

--- a/content/posts/sitincator-simplificators-meeting-room-display.md
+++ b/content/posts/sitincator-simplificators-meeting-room-display.md
@@ -3,6 +3,10 @@ title: "“Sitincator” - Simplificator’s Meeting Room Display"
 date: 2017-01-12
 language: en
 author: Serge Hänni
+tags:
+  - elm
+  - react
+  - raspberry-pi
 ---
 
 {% image "./content/images/image03.png", "Sitincator displays in front of meeting rooms" %}

--- a/content/posts/staging-umgebung-auf-heroku-erstellen.md
+++ b/content/posts/staging-umgebung-auf-heroku-erstellen.md
@@ -3,6 +3,8 @@ title: "Staging Umgebung auf Heroku erstellen"
 date: 2014-01-06
 language: de
 author: Simplificator
+tags:
+  - rails
 ---
 
 Für einige Kunden verwenden wir das Rails Hosting von [heroku](http://heroku.com). Es bietet sich dann an, auch die staging Umgebung auf heroku zu betreiben damit keine wesentlichen Unterschiede zur produktions Umgebung bestehen.

--- a/content/posts/und-mal-wieder-ein-grund-warum-ich-recruiters.md
+++ b/content/posts/und-mal-wieder-ein-grund-warum-ich-recruiters.md
@@ -3,6 +3,8 @@ title: "Und mal wieder ein Grund warum ich Recruiters nicht berücksichtige"
 date: 2013-05-01
 language: de
 author: Simplificator
+tags:
+  - recruiters
 ---
 
 1\. Mai, ich kann ausschlafen da ein Feiertag. Das Telefon klingelt mit einer Nummer aus England. 

--- a/content/posts/use-a-raspberry-pi-3-as-an-access-point.md
+++ b/content/posts/use-a-raspberry-pi-3-as-an-access-point.md
@@ -3,6 +3,8 @@ title: "Use a Raspberry Pi 3 as an access point"
 date: 2017-04-28
 language: en
 author: Mario Schüttel
+tags:
+  - raspberry-pi
 ---
 
 {% image "./content/images/raspberry-pi-logo.png", "raspberry-pi-logo" %}

--- a/content/posts/values.md
+++ b/content/posts/values.md
@@ -3,6 +3,8 @@ title: "Values"
 date: 2015-03-02
 language: en
 author: Pascal Betz
+tags:
+  - values
 ---
 
 It's always great to visit a customer and see the magnets with our five values in their offices:

--- a/content/posts/vaults-with-ansible.md
+++ b/content/posts/vaults-with-ansible.md
@@ -3,6 +3,8 @@ title: "Vaults with Ansible"
 date: 2017-03-30
 language: en
 author: Mario Schüttel
+tags:
+  - ansible
 ---
 
 When it comes to software versioning, you normally do not want to upload passwords or secrets into shared repositories. Too many people might have access to the code, and it's irresponsible to have secrets there without protection.

--- a/content/posts/vcr-tests-mit-custom-matcher.md
+++ b/content/posts/vcr-tests-mit-custom-matcher.md
@@ -3,6 +3,9 @@ title: "VCR Tests mit Custom matcher"
 date: 2014-03-05
 language: de
 author: Simplificator
+tags:
+  - testing
+  - vcr
 ---
 
 [VCR](https://relishapp.com/vcr/vcr/v/2-8-0/docs) ist ein Library um Tests zu schreiben welche HTTP Requests auf externe Services machen.

--- a/content/posts/webtuesday-about-rails.md
+++ b/content/posts/webtuesday-about-rails.md
@@ -3,6 +3,11 @@ title: "Webtuesday about Rails"
 date: 2013-02-12
 language: en
 author: Simplificator
+tags:
+  - events
+  - rails
+  - ruby
+  - zurich
 ---
 
 Our customer [local.ch](http://local.ch) is hosting a Webtuesday tonight at 19:30, where Jeremy talks about the experience of introducing Ruby on Rails, an effort Simplificator was able to support in several projects. Location: the local.ch office at Konradstrasse 12, 8005 Zürich. More info [here](http://webtuesday.ch/meetings/20130212/) - the gist of it below.

--- a/content/posts/wie-kann-man-verhindern-dass-softwareentwicklung.md
+++ b/content/posts/wie-kann-man-verhindern-dass-softwareentwicklung.md
@@ -3,6 +3,10 @@ title: "Wie kann man verhindern, dass Softwareentwicklung ins Stocken kommt?"
 date: 2013-05-24
 language: de
 author: Simplificator
+tags:
+  - consulting
+  - quality
+  - refactoring
 ---
 
 Eine typische Situation nach den ersten Erfolgen mit einer Applikation: **Das Team ist langsam,** wehrt sich gegen Anforderungen. Neue Funktionen sind schwierig umzusetzen, und die Testphasen werden länger. Die Software-**Entwicklung wird immer schwieriger**.

--- a/content/posts/wie-konnen-wir-uberhaupt-in-der-schweiz.md
+++ b/content/posts/wie-konnen-wir-uberhaupt-in-der-schweiz.md
@@ -3,6 +3,10 @@ title: "Wie können wir überhaupt in der Schweiz entwickeln?"
 date: 2013-05-03
 language: de
 author: Simplificator
+tags:
+  - agile
+  - outsourcing
+  - rails
 ---
 
 Ist es nicht viel zu teuer in der Schweiz Software zu entwickeln? Sätze in Indonesien, Indien, China oder Polen sind Faktoren tiefer als in der Schweiz. Warum müssen wir denn hier entwickeln? Mit Skype und allem müsste es doch einfach sein, im Ausland zu entwickeln - so kostengünstig dass eventuelle Kostenabweichungen oder Ineffizienzen überwunden werden können. Irgendwas stimmt mit dieser Rechnung offenbar nicht.

--- a/content/posts/xcode-7-and-the-circleci.md
+++ b/content/posts/xcode-7-and-the-circleci.md
@@ -3,6 +3,10 @@ title: "Xcode 7 and the CircleCI"
 date: 2015-10-20
 language: en
 author: Lucian Cancescu
+tags:
+  - circleci
+  - xcode
+  - ios
 ---
 
 We're using CircleCI for one of our iOS projects and recently we migrated to Xcode 7. However, since the migration we noticed that the builds on CircleCI started to fail. Even worse, all tests were passing locally in Xcode.

--- a/content/posts/zur-junior-softwareentwicklerin-in-5-schritten.md
+++ b/content/posts/zur-junior-softwareentwicklerin-in-5-schritten.md
@@ -3,6 +3,8 @@ title: Zur Junior Softwareentwicklerin in 5 Schritten
 date: 2021-04-07
 language: de
 author: Tatiana Panferova
+tags:
+  - internship
 ---
 
 Hin und wieder werde ich gefragt, was man beachten muss, wenn man sich Mitte 30 nochmals beruflich neu orientiert. Ganz einfach: Mut fassen und Prioritäten setzen. Klar ist das nicht so einfach, wie es klingt. Klärt man für sich jedoch einige wesentlichen Punkte, wird aus dieser komplexen Entscheidung ein gangbarer Weg sichtbar. Meiner sah so aus:


### PR DESCRIPTION
This pull request adds tags to each blog post and documents how to do it (in the README). The tags are not used yet.

I extracted tags and categories from the WordPress export of the old blog and combined them into tags. I then tagged newer blog posts and any old posts that did not have tags, but could use some.